### PR TITLE
Add link to code repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ The paper was successfully submitted for the Geometric Deep Learning Workshop at
 
 Access the paper here: https://drive.google.com/file/d/11ADht4hmCCN1hUuiP6l3pB3Tj3Uw1HJ1/view?usp=sharing
 
+The code can be found in [`artm-github`](https://github.com/mood2jam/artm-github) repository.


### PR DESCRIPTION
Adding link to the [`artm-github`](https://github.com/mood2jam/artm-github) repository in the README for more clarification.
The [paper (version of ICCVW 2019)](https://openaccess.thecvf.com/content_ICCVW_2019/papers/GMDL/Nina_A_Decoder-Free_Approach_for_Unsupervised_Clustering_and_Manifold_Learning_with_ICCVW_2019_paper.pdf) links here (`ARTM` repository).